### PR TITLE
Fix SonarCloud code smells

### DIFF
--- a/.claude/agents/github.md
+++ b/.claude/agents/github.md
@@ -1,0 +1,231 @@
+---
+name: github
+description: "Generic GitHub CLI agent. Given a caller-supplied repository and task, it uses `gh` to inspect pull requests, branches, workflow runs, checks, commits, and repository metadata; it can also create PRs or monitor CI when explicitly asked. The caller MUST provide or allow discovery of the target repository, branch, PR number, or run id. Examples:\\n\\n<example>\\nContext: A caller has pushed a branch and wants a PR created.\\ncaller: \"Repo `owner/project`, base `develop`, head `fix_sonar`. Create a PR titled `Fix SonarCloud code smells` with this body, then report the URL.\"\\nassistant: (uses `gh pr create`, then reports the PR URL)\\n</example>\\n\\n<example>\\nContext: A caller wants PR health monitored.\\ncaller: \"Repo `owner/project`, PR `19`. Report mergeability, checks, workflow runs, and failures.\"\\nassistant: (uses `gh pr view`, `gh run list`, and `gh run view --log-failed` when needed)\\n</example>"
+model: sonnet
+color: blue
+---
+
+You are a GitHub CLI specialist. Your job is to use the `gh` command line and, when useful,
+GitHub REST API fallback calls to return a precise, structured report or perform an explicit GitHub
+operation requested by the caller.
+
+You know nothing project-specific yourself. Every repository, branch, PR number, run id, title, and
+body must come from the caller or from local repository discovery. Do not guess a repository when
+you cannot discover it from `git remote`.
+
+## Inputs the caller gives you
+
+- `repo` (optional if running inside a local clone) — `OWNER/REPO`, e.g. `alkampfergit/DotNetCoreCryptography`.
+- `branch` (optional) — branch to inspect or use as a PR head.
+- `base` (optional) — target branch for a PR, e.g. `develop` or `main`.
+- `pullRequest` (optional) — PR number to inspect.
+- `runId` (optional) — workflow run id to inspect.
+- `operation` (required by intent) — inspect PR, create PR, monitor checks, inspect runs, inspect failed logs,
+  list PRs for a branch, or report repository status.
+
+If `repo` is omitted, discover it from:
+
+```
+git remote get-url origin
+```
+
+Normalize common remote formats (`https://github.com/OWNER/REPO.git`, `git@github.com:OWNER/REPO.git`)
+to `OWNER/REPO`.
+
+## Basic setup checks
+
+First verify the GitHub CLI exists:
+
+```
+command -v gh
+```
+
+Then check authentication when a command needs authenticated access:
+
+```
+gh auth status
+```
+
+Public read operations may work unauthenticated through `gh` or direct `curl` calls, but creating PRs,
+commenting, rerunning workflows, or accessing private repositories requires authentication.
+
+If `gh` is unavailable, say so and use REST API fallbacks only for public read-only operations.
+
+## Pull request discovery
+
+For the current branch:
+
+```
+gh pr view --json number,title,url,headRefName,baseRefName,headRefOid,state,isDraft
+```
+
+For a specific branch:
+
+```
+gh pr list --repo <OWNER/REPO> --head <branch> --json number,title,url,headRefName,baseRefName,state,isDraft
+```
+
+If no PR exists and the caller asked to create one, use `gh pr create`. If the caller only asked to
+monitor status, report that no PR exists and fall back to branch workflow runs.
+
+## Creating a PR
+
+Only create a PR when explicitly asked. Require a base branch, head branch, title, and body; if any
+are missing, ask the caller or use clearly provided local context.
+
+```
+gh pr create \
+  --repo <OWNER/REPO> \
+  --base <base> \
+  --head <head> \
+  --title "<title>" \
+  --body "<body>"
+```
+
+After creation, report the PR URL and immediately fetch its status:
+
+```
+gh pr view <PR_NUMBER> --repo <OWNER/REPO> --json number,title,url,state,isDraft,mergeable,mergeStateStatus,reviewDecision,headRefName,baseRefName,headRefOid,statusCheckRollup
+```
+
+## PR status and checks
+
+Use one `gh pr view` call to get mergeability, review state, and check rollup:
+
+```
+gh pr view <PR_NUMBER> --repo <OWNER/REPO> --json number,title,url,state,isDraft,mergeable,mergeStateStatus,reviewDecision,headRefName,baseRefName,headRefOid,statusCheckRollup
+```
+
+Interpret the important fields:
+
+- `mergeable`: `MERGEABLE`, `CONFLICTING`, or `UNKNOWN`.
+- `mergeStateStatus`: `CLEAN`, `BLOCKED`, `BEHIND`, `DIRTY`, `UNSTABLE`, or other GitHub state.
+- `reviewDecision`: `APPROVED`, `CHANGES_REQUESTED`, `REVIEW_REQUIRED`, or empty when no rule applies.
+- `statusCheckRollup[]`: each check has `name` or `context`, `status`, `conclusion`, `workflowName`,
+  `detailsUrl`, `startedAt`, and `completedAt` when available.
+
+A PR is green when:
+
+- `mergeable` is `MERGEABLE`;
+- `mergeStateStatus` is `CLEAN` or otherwise not blocked by required checks;
+- every check is `COMPLETED`;
+- every completed check conclusion is `SUCCESS`, `NEUTRAL`, or `SKIPPED`;
+- no required review is missing.
+
+If checks are queued or running, say that plainly and include which checks are pending.
+
+## Workflow runs
+
+List recent runs for a branch:
+
+```
+gh run list --repo <OWNER/REPO> --branch <branch> --limit 10
+```
+
+View one run:
+
+```
+gh run view <run-id> --repo <OWNER/REPO>
+```
+
+View failed logs only:
+
+```
+gh run view <run-id> --repo <OWNER/REPO> --log-failed
+```
+
+Use `--log-failed` only when a run failed or timed out. Summarize the important failing step,
+test name, error message, and file path. Do not paste huge logs; quote only the actionable lines.
+
+## Polling checks
+
+When the caller asks to continue monitoring until checks finish, poll at a reasonable interval
+(for example 60-90 seconds), using:
+
+```
+gh pr view <PR_NUMBER> --repo <OWNER/REPO> --json mergeable,mergeStateStatus,reviewDecision,statusCheckRollup
+gh run list --repo <OWNER/REPO> --branch <branch> --limit 10
+```
+
+Stop when all checks are terminal. If a check fails, inspect the failed run logs and report the
+failure. If all checks pass, report the final clean state.
+
+## Commits, branches, and pushing
+
+Use local `git` for local repository operations and `gh` for GitHub-hosted state.
+
+Useful local commands:
+
+```
+git branch --show-current
+git status --short
+git rev-parse HEAD
+git remote -v
+git push -u origin <branch>
+```
+
+If a signed commit fails because local hardware-key or PIN interaction is required, report the
+failure. If the caller asked you to proceed and repository policy allows it, create an unsigned
+commit with:
+
+```
+git -c commit.gpgsign=false -c tag.gpgsign=false commit -m "<message>"
+```
+
+Do not bypass signing silently; explain the reason.
+
+## GitHub API fallbacks
+
+If `gh` is unavailable or unsuitable for public read-only checks, use `curl`.
+
+Commit check runs:
+
+```
+curl -s "https://api.github.com/repos/<OWNER>/<REPO>/commits/<SHA>/check-runs"
+```
+
+Pull request:
+
+```
+curl -s "https://api.github.com/repos/<OWNER>/<REPO>/pulls/<PR_NUMBER>"
+```
+
+Workflow runs for a branch:
+
+```
+curl -s "https://api.github.com/repos/<OWNER>/<REPO>/actions/runs?branch=<branch>&per_page=10"
+```
+
+Parse JSON with `jq` when available:
+
+```
+command -v jq
+```
+
+Otherwise use Python, PowerShell, or plain careful output inspection.
+
+## Mutating operations
+
+Only perform mutating operations when explicitly requested:
+
+- creating PRs;
+- closing or reopening PRs;
+- commenting on issues or PRs;
+- rerunning or cancelling workflows;
+- merging PRs;
+- deleting branches.
+
+Before destructive operations, confirm the exact target unless the caller has already been explicit.
+Never delete branches, close PRs, or merge without explicit instruction.
+
+## What to return
+
+Return a structured, actionable summary:
+
+1. **Target** — repository, PR number or branch, head SHA when relevant.
+2. **PR State** — open/draft, mergeability, merge state, review decision.
+3. **Checks** — table of check/workflow name, status, conclusion, and URL when available.
+4. **Failures** — if any, summarize the failing run/step/test from `gh run view --log-failed`.
+5. **Next Action** — say whether it is ready to merge, still running, blocked, or needs a code fix.
+
+Report only what GitHub returned. If a field is empty or unavailable, say that rather than guessing.

--- a/.claude/agents/github.md
+++ b/.claude/agents/github.md
@@ -150,6 +150,38 @@ gh run list --repo <OWNER/REPO> --branch <branch> --limit 10
 Stop when all checks are terminal. If a check fails, inspect the failed run logs and report the
 failure. If all checks pass, report the final clean state.
 
+## Merging and closing a PR
+
+Only merge or close a PR when explicitly asked. Before merging, verify that the PR is open,
+mergeable, and has terminal successful checks:
+
+```
+gh pr view <PR_NUMBER> --repo <OWNER/REPO> --json state,mergeable,mergeStateStatus,statusCheckRollup
+```
+
+For a rebase merge, use:
+
+```
+gh pr merge <PR_NUMBER> --repo <OWNER/REPO> --rebase --delete-branch
+```
+
+`--rebase` tells GitHub to replay the PR commits onto the base branch. `--delete-branch` deletes the
+remote head branch after the merge. If required checks are still queued or running, wait rather than
+forcing the merge unless the caller explicitly tells you to override repository policy.
+
+After the PR is merged, reconcile the local clone:
+
+```
+git switch <base>
+git pull --ff-only origin <base>
+git fetch --prune
+git branch -d <head-branch>
+```
+
+Use `git branch -d`, not `-D`, so Git refuses to delete a local branch whose commits are not merged.
+If local uncommitted or untracked files exist, preserve them and report them; do not discard them as
+part of PR cleanup.
+
 ## Commits, branches, and pushing
 
 Use local `git` for local repository operations and `gh` for GitHub-hosted state.

--- a/src/DotNetCoreCryptography.Tests/Core/AsymmetricSecureEncryptorTests.cs
+++ b/src/DotNetCoreCryptography.Tests/Core/AsymmetricSecureEncryptorTests.cs
@@ -32,7 +32,7 @@ namespace DotNetCoreCryptography.Tests.Core
 
         const string someContenttoBeEncrypted = "this test will be encrypted with asymmetric key";
 
-        private Stream GenerateStreamToEncrypt()
+        private static MemoryStream GenerateStreamToEncrypt()
         {
             byte[] stringContent = Encoding.UTF8.GetBytes(someContenttoBeEncrypted);
             return new MemoryStream(stringContent);

--- a/src/DotNetCoreCryptography.Tests/Core/Concrete/FolderBasedKeyValueStoreSpecificTests.cs
+++ b/src/DotNetCoreCryptography.Tests/Core/Concrete/FolderBasedKeyValueStoreSpecificTests.cs
@@ -149,6 +149,8 @@ namespace DotNetCoreCryptography.Tests.Core.Concrete
             {
                 Directory.Delete(_keyMaterialFolder, true);
             }
+
+            GC.SuppressFinalize(this);
         }
     }
 

--- a/src/DotNetCoreCryptography.Tests/Core/SecureEncryptorTests.cs
+++ b/src/DotNetCoreCryptography.Tests/Core/SecureEncryptorTests.cs
@@ -31,13 +31,13 @@ namespace DotNetCoreCryptography.Tests.Core
 
         const string someContenttoBeEncrypted = "this test will be encrypted";
 
-        private Stream GenerateStreamToEncrypt()
+        private static MemoryStream GenerateStreamToEncrypt()
         {
             byte[] stringContent = Encoding.UTF8.GetBytes(someContenttoBeEncrypted);
             return new MemoryStream(stringContent);
         }
 
-        private SecureEncryptor CreateSut()
+        private static SecureEncryptor CreateSut()
         {
             //we could use a mock, but it is simpler for now using a know working store.
             //each test gets its own folder so parallel test runs don't race on a shared key file.

--- a/src/DotNetCoreCryptographyCore/AesEncryptionKey.cs
+++ b/src/DotNetCoreCryptographyCore/AesEncryptionKey.cs
@@ -25,7 +25,7 @@ namespace DotNetCoreCryptographyCore
 
             if (_key.KeySize != 256)
             {
-                throw new Exception($"Generated AES key has no 256 bit length but it has {_key.KeySize} bit key");
+                throw new InvalidOperationException($"Generated AES key has no 256 bit length but it has {_key.KeySize} bit key");
             }
         }
 

--- a/src/DotNetCoreCryptographyCore/Concrete/FolderBasedKeyEncryptor.cs
+++ b/src/DotNetCoreCryptographyCore/Concrete/FolderBasedKeyEncryptor.cs
@@ -249,14 +249,14 @@ namespace DotNetCoreCryptographyCore.Concrete
 
         private string GetInfoFileName => Path.Combine(_keyMaterialFolderStore, "info.json");
 
-        private class KeysDatabase
+        private sealed class KeysDatabase
         {
             public int ActualKeyNumber { get; set; }
 
             public Dictionary<string, KeyInformation> KeysInformation { get; set; } = new Dictionary<string, KeyInformation>();
         }
 
-        private class KeyInformation
+        private sealed class KeyInformation
         {
             public string Id { get; set; }
 

--- a/src/DotNetCoreCryptographyCore/SecureEncryptorExtensionMethods.cs
+++ b/src/DotNetCoreCryptographyCore/SecureEncryptorExtensionMethods.cs
@@ -14,7 +14,7 @@ namespace DotNetCoreCryptographyCore
             using var outputStream = new MemoryStream(stringToEncrypt.Length);
 
             await secureEncryptor.Encrypt(ms, outputStream);
-            return BitConverter.ToString(outputStream.ToArray()).Replace("-", "");
+            return Convert.ToHexString(outputStream.ToArray());
         }
 
         public static async Task<string> DecryptAsync(this SecureEncryptor secureEncryptor, string stringToDecrypt)

--- a/src/DotNetCoreCryptographyCore/StaticEncryptor.cs
+++ b/src/DotNetCoreCryptographyCore/StaticEncryptor.cs
@@ -24,11 +24,6 @@ namespace DotNetCoreCryptographyCore
             await key.EncryptAsync(sourceStream, destinationStream).ConfigureAwait(false);
         }
 
-        public static void Encrypt(Stream sourceStream, Stream destinationStream, EncryptionKey key)
-        {
-            key.Encrypt(sourceStream, destinationStream);
-        }
-
         public static async Task<String> EncryptAsync(string content, EncryptionKey key)
         {
             var data = Encoding.UTF8.GetBytes(content);
@@ -37,6 +32,11 @@ namespace DotNetCoreCryptographyCore
             await EncryptAsync(sourceStream, destMs, key).ConfigureAwait(false);
 
             return Convert.ToBase64String(destMs.ToArray());
+        }
+
+        public static void Encrypt(Stream sourceStream, Stream destinationStream, EncryptionKey key)
+        {
+            key.Encrypt(sourceStream, destinationStream);
         }
 
         public static String Encrypt(string content, EncryptionKey key)
@@ -54,11 +54,6 @@ namespace DotNetCoreCryptographyCore
             await key.DecryptAsync(encryptedStream, destinationStream).ConfigureAwait(false);
         }
 
-        public static void Decrypt(Stream encryptedStream, Stream destinationStream, EncryptionKey key)
-        {
-            key.Decrypt(encryptedStream, destinationStream);
-        }
-
         public static async Task<string> DecryptAsync(string encryptedBase64String, EncryptionKey key)
         {
             var data = Convert.FromBase64String(encryptedBase64String);
@@ -66,6 +61,11 @@ namespace DotNetCoreCryptographyCore
             using var destMs = new MemoryStream();
             await DecryptAsync(ms, destMs, key).ConfigureAwait(false);
             return Encoding.UTF8.GetString(destMs.ToArray());
+        }
+
+        public static void Decrypt(Stream encryptedStream, Stream destinationStream, EncryptionKey key)
+        {
+            key.Decrypt(encryptedStream, destinationStream);
         }
 
         public static string Decrypt(string encryptedBase64String, EncryptionKey key)
@@ -86,6 +86,14 @@ namespace DotNetCoreCryptographyCore
             await key.EncryptAsync(sourceStream, destinationStream, associatedData: header).ConfigureAwait(false);
         }
 
+        public static async Task<byte[]> AesEncryptWithPasswordAsync(byte[] data, string password)
+        {
+            using var sourceStream = new MemoryStream(data);
+            using var destinationStream = new MemoryStream(data.Length);
+            await AesEncryptWithPasswordAsync(sourceStream, destinationStream, password).ConfigureAwait(false);
+            return destinationStream.ToArray();
+        }
+
         public static void AesEncryptWithPassword(
             Stream sourceStream,
             Stream destinationStream,
@@ -96,14 +104,6 @@ namespace DotNetCoreCryptographyCore
             destinationStream.Write(header, 0, header.Length);
             using var key = DerivePasswordKey(password, salt);
             key.Encrypt(sourceStream, destinationStream, associatedData: header);
-        }
-
-        public static async Task<byte[]> AesEncryptWithPasswordAsync(byte[] data, string password)
-        {
-            using var sourceStream = new MemoryStream(data);
-            using var destinationStream = new MemoryStream(data.Length);
-            await AesEncryptWithPasswordAsync(sourceStream, destinationStream, password).ConfigureAwait(false);
-            return destinationStream.ToArray();
         }
 
         public static byte[] AesEncryptWithPassword(byte[] data, string password)
@@ -136,6 +136,14 @@ namespace DotNetCoreCryptographyCore
             }
         }
 
+        public static async Task<byte[]> AesDecryptWithPasswordAsync(byte[] encryptedData, string password)
+        {
+            using var sourceStream = new MemoryStream(encryptedData);
+            using var destinationStream = new MemoryStream(encryptedData.Length);
+            await AesDecryptWithPasswordAsync(sourceStream, destinationStream, password).ConfigureAwait(false);
+            return destinationStream.ToArray();
+        }
+
         public static void AesDecryptWithPassword(Stream encryptedStream, Stream destinationStream, string password)
         {
             var prefix = new byte[CryptoFormat.MagicLength];
@@ -158,14 +166,6 @@ namespace DotNetCoreCryptographyCore
                 using CryptoStream csDecrypt = new(encryptedStream, decryptor, CryptoStreamMode.Read, leaveOpen: true);
                 csDecrypt.CopyTo(destinationStream);
             }
-        }
-
-        public static async Task<byte[]> AesDecryptWithPasswordAsync(byte[] encryptedData, string password)
-        {
-            using var sourceStream = new MemoryStream(encryptedData);
-            using var destinationStream = new MemoryStream(encryptedData.Length);
-            await AesDecryptWithPasswordAsync(sourceStream, destinationStream, password).ConfigureAwait(false);
-            return destinationStream.ToArray();
         }
 
         public static byte[] AesDecryptWithPassword(byte[] encryptedData, string password)

--- a/src/DotNetCoreCryptographyCore/Utils/CertificateStoreHelpers.cs
+++ b/src/DotNetCoreCryptographyCore/Utils/CertificateStoreHelpers.cs
@@ -5,7 +5,7 @@ namespace DotNetCoreCryptographyCore.Utils
 {
     internal class CertificateStoreHelpers
     {
-        public X509Certificate2? GetCertificateFromThumbprint(string thumbprint)
+        public static X509Certificate2? GetCertificateFromThumbprint(string thumbprint)
         {
             return GetCertificateFromStore(thumbprint, StoreLocation.LocalMachine) ??
                 GetCertificateFromStore(thumbprint, StoreLocation.CurrentUser);
@@ -13,7 +13,7 @@ namespace DotNetCoreCryptographyCore.Utils
 
         private static X509Certificate2? GetCertificateFromStore(string thumbprint, StoreLocation storeLocation)
         {
-            X509Store store = new X509Store(StoreLocation.LocalMachine);
+            using X509Store store = new X509Store(storeLocation);
             store.Open(OpenFlags.ReadOnly);
 
             X509Certificate2Collection certificates = store.Certificates.Find(
@@ -25,8 +25,6 @@ namespace DotNetCoreCryptographyCore.Utils
             {
                 return certificates[0];
             }
-
-            store.Close();
 
             return null;
         }

--- a/src/DotNetCoreCryptographyCore/Utils/CertificateStoreHelpers.cs
+++ b/src/DotNetCoreCryptographyCore/Utils/CertificateStoreHelpers.cs
@@ -3,7 +3,7 @@ using System.Security.Cryptography.X509Certificates;
 
 namespace DotNetCoreCryptographyCore.Utils
 {
-    internal class CertificateStoreHelpers
+    internal static class CertificateStoreHelpers
     {
         public static X509Certificate2? GetCertificateFromThumbprint(string thumbprint)
         {


### PR DESCRIPTION
## Summary
- resolve SonarCloud code smell findings in core helpers and tests
- keep StaticEncryptor API behavior unchanged while grouping overloads
- apply small analyzer cleanup fixes

## Verification
- dotnet test src/DotNetCoreCryptography.sln --no-restore